### PR TITLE
Add Stream spectrum analyzer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ BLE(Bluetooth Low Energy) を使ったサンプルです。
 ### ble/line-things
 
 - [line/line-things-starter](https://github.com/line/line-things-starter)のModdableSDK向け移植です。
+
+### spectrum-analyzer
+
+Web Streams APIで音声入力をFFT Workerへ渡し、Piuの`Port`でリアルタイム表示するスペクトラムアナライザーです。LINシミュレーター用の1 kHzテスト信号も利用できます。

--- a/spectrum-analyzer/README.md
+++ b/spectrum-analyzer/README.md
@@ -1,0 +1,62 @@
+# Moddable Stream + Piu Spectrum Analyzer
+
+Moddable SDK 9.0.0の`AudioIn`をWeb Streams APIへ接続し、Piuの軽量描画オブジェクト`Port`でリアルタイム表示するスペクトラムアナライザーです。
+
+## 構成
+
+```
+AudioIn → ReadableStream → Worker-backed WritableStream → Worker (Hann窓 / FFT / 対数バンド) → Piu Port
+```
+
+- 入力: 22.05 kHz / mono / signed 16-bit LPCM
+- 解析: 256点 radix-2 FFT、24本の対数周波数バンド、約21.5 Hz更新
+- 表示: バー、ピークホールド、支配周波数、dBFS
+- 遅延対策: Streamのbackpressureが掛かったときは古い入力を破棄し、表示待ちを蓄積しません
+- 描画負荷対策: バーごとのPiu `Content`を作らず、単一の`Port`から直接描画します
+- 応答性対策: FFTは独立したModdable `Worker` VMで実行し、Piu/UIのVMをブロックしません
+
+## 実行
+
+PCのマイクとModdable Simulatorを使う場合:
+
+```sh
+mcconfig -d -m -p lin
+```
+
+macOSでは`lin`を`mac`、Windowsでは`win`に置き換えます。
+
+録音デバイスがない環境では、1 kHzの内蔵テスト信号でStream・FFT・描画の全経路を確認できます:
+
+```sh
+mcconfig -d -m -p lin syntheticAudio=true
+```
+
+グラフ内に約`1.0kHz / -6dB`と表示され、1 kHz付近のバーが上がれば正常です。256点FFTの周波数分解能は約86 Hzです。`syntheticAudio`を省略するか`false`にすると実マイク入力へ戻ります。
+
+CPU負荷を確認するときはデバッガ計測を含まないreleaseビルドも使えます:
+
+```sh
+mcconfig -m -p lin syntheticAudio=true
+```
+
+`-d`ではメインVMとWorker VMの両方にXSのデバッグ計測が入るため、release版よりCPU使用率が大きくなります。debug版の`mc.so`を`mcsim`から直接起動する場合は、先に`xsbug`を起動してください。デバッガ未接続のWorkerは計測値を標準出力へ送るため、負荷測定を歪めます。
+
+M5Stack Core2（内蔵マイク・320×240ディスプレイ）の例:
+
+```sh
+mcconfig -d -m -p esp32/m5stack_core2
+```
+
+対象ボードのmanifestに`audioIn`と画面ドライバが定義されていれば、同じアプリをそのターゲット名でビルドできます。外付けI²Sマイクを使う場合は、対象ボードmanifestの`defines.audioIn.i2s`で`bck_pin`、`lr_pin`、`datain`、必要なら`format_i2s`や`slot`を設定してください。
+
+解析条件は[config.js](./config.js)に集約しています。`analysisEveryFrames`でFFT更新頻度、`displayFPS`で描画上限、`hopSize`でオーバーラップ量を調整できます。
+
+## 主なファイル
+
+- `audio-stream.js`: `AudioIn`をbounded `ReadableStream`に変換
+- `tone-stream.js`: シミュレーター確認用の1 kHzテスト信号
+- `fft-spectrum.js`: Hann窓、FFT、対数バンド集約
+- `spectrum-worker.js`: FFTを実行するWorkerエントリ
+- `spectrum-worker-stream.js`: backpressure付きWorker `WritableStream`
+- `spectrum-port.js`: 1個のPiu `Port`による可視化
+- `main.js`: Streamパイプラインの接続

--- a/spectrum-analyzer/audio-stream.js
+++ b/spectrum-analyzer/audio-stream.js
@@ -1,0 +1,51 @@
+import AudioIn from "embedded:io/audio/in";
+import { ReadableStream } from "web/streams";
+
+/*
+ * Turns AudioIn's callback API into a bounded stream of Int16Array chunks.
+ * AudioIn must always be drained; when downstream is behind, the oldest input
+ * is discarded instead of allowing latency to grow without bound.
+ */
+export default class AudioSampleStream extends ReadableStream {
+	constructor(options = {}) {
+		let input;
+		let discardBuffer = new ArrayBuffer(2048);
+
+		super({
+			start(controller) {
+				input = new AudioIn({
+					sampleRate: options.sampleRate,
+					channels: 1,
+					bitsPerSample: 16,
+					onReadable(byteLength) {
+						// LPCM16 always arrives on a two-byte boundary.
+						byteLength &= ~1;
+						if (!byteLength)
+							return;
+
+						if (controller.desiredSize > 0) {
+							const buffer = this.read(byteLength);
+							controller.enqueue(new Int16Array(buffer));
+						}
+						else {
+							if (discardBuffer.byteLength < byteLength)
+								discardBuffer = new ArrayBuffer(byteLength);
+							this.read(new Uint8Array(discardBuffer, 0, byteLength));
+						}
+					},
+				});
+				input.start();
+			},
+			cancel() {
+				if (input) {
+					input.stop();
+					input.close();
+					input = undefined;
+				}
+			},
+		}, {
+			highWaterMark: 2,
+			size() { return 1; },
+		});
+	}
+}

--- a/spectrum-analyzer/config.js
+++ b/spectrum-analyzer/config.js
@@ -1,0 +1,15 @@
+const SpectrumConfig = Object.freeze({
+	sampleRate: 22050,
+	fftSize: 256,
+	hopSize: 256,
+	inputChunkSize: 512,
+	analysisEveryFrames: 4,
+	displayFPS: 20,
+	bandCount: 24,
+	minFrequency: 60,
+	minDecibels: -80,
+	maxDecibels: -10,
+	smoothing: 0.68,
+});
+
+export default SpectrumConfig;

--- a/spectrum-analyzer/fft-spectrum.js
+++ b/spectrum-analyzer/fft-spectrum.js
@@ -1,0 +1,198 @@
+const LOG10 = 0.4342944819032518;
+
+export default class FFTSpectrum {
+	#size;
+	#hopSize;
+	#sampleRate;
+	#bandCount;
+	#minDecibels;
+	#maxDecibels;
+	#smoothing;
+	#analysisEveryFrames;
+	#frameCounter = 0;
+	#frame;
+	#frameLength = 0;
+	#real;
+	#imaginary;
+	#window;
+	#windowSum = 0;
+	#bitReverse;
+	#cosine;
+	#sine;
+	#bandStart;
+	#bandEnd;
+	#smoothed;
+	#levels;
+	#spectrum;
+
+	constructor(options) {
+		const size = options.fftSize;
+		if ((size < 64) || (size & (size - 1)))
+			throw new RangeError("fftSize must be a power of two >= 64");
+		if ((options.hopSize < 1) || (options.hopSize > size))
+			throw new RangeError("hopSize must be between 1 and fftSize");
+
+		this.#size = size;
+		this.#hopSize = options.hopSize;
+		this.#sampleRate = options.sampleRate;
+		this.#bandCount = options.bandCount;
+		this.#minDecibels = options.minDecibels;
+		this.#maxDecibels = options.maxDecibels;
+		this.#smoothing = options.smoothing;
+		this.#analysisEveryFrames = options.analysisEveryFrames ?? 1;
+		this.#frame = new Float32Array(size);
+		this.#real = new Float32Array(size);
+		this.#imaginary = new Float32Array(size);
+		this.#window = new Float32Array(size);
+		this.#bitReverse = new Uint16Array(size);
+		this.#cosine = new Float32Array(size >> 1);
+		this.#sine = new Float32Array(size >> 1);
+		this.#bandStart = new Uint16Array(options.bandCount);
+		this.#bandEnd = new Uint16Array(options.bandCount);
+		this.#smoothed = new Float32Array(options.bandCount);
+		this.#levels = new Uint8Array(options.bandCount);
+		this.#spectrum = {
+			levels: this.#levels,
+			peakFrequency: 0,
+			peakDecibels: options.minDecibels,
+		};
+		this.#prepareTables(options.minFrequency);
+	}
+
+	#prepareTables(minFrequency) {
+		const size = this.#size;
+		const bits = Math.round(Math.log(size) / Math.LN2);
+		for (let i = 0; i < size; i++) {
+			const window = 0.5 - (0.5 * Math.cos((2 * Math.PI * i) / (size - 1)));
+			this.#window[i] = window;
+			this.#windowSum += window;
+
+			let value = i;
+			let reversed = 0;
+			for (let bit = 0; bit < bits; bit++) {
+				reversed = (reversed << 1) | (value & 1);
+				value >>= 1;
+			}
+			this.#bitReverse[i] = reversed;
+		}
+
+		for (let i = 0; i < (size >> 1); i++) {
+			const angle = (2 * Math.PI * i) / size;
+			this.#cosine[i] = Math.cos(angle);
+			this.#sine[i] = -Math.sin(angle);
+		}
+
+		const nyquist = this.#sampleRate / 2;
+		const ratio = nyquist / minFrequency;
+		for (let band = 0; band < this.#bandCount; band++) {
+			const low = minFrequency * Math.pow(ratio, band / this.#bandCount);
+			const high = minFrequency * Math.pow(ratio, (band + 1) / this.#bandCount);
+			let start = Math.floor((low * size) / this.#sampleRate);
+			let end = Math.ceil((high * size) / this.#sampleRate);
+			if (start < 1)
+				start = 1;
+			if (end <= start)
+				end = start + 1;
+			if (end > (size >> 1))
+				end = size >> 1;
+			this.#bandStart[band] = start;
+			this.#bandEnd[band] = end;
+			this.#smoothed[band] = this.#minDecibels;
+		}
+	}
+
+	push(samples, emit) {
+		let sourceOffset = 0;
+		while (sourceOffset < samples.length) {
+			const count = Math.min(samples.length - sourceOffset, this.#size - this.#frameLength);
+			for (let i = 0; i < count; i++)
+				this.#frame[this.#frameLength + i] = samples[sourceOffset + i] / 32768;
+			this.#frameLength += count;
+			sourceOffset += count;
+
+			if (this.#frameLength === this.#size) {
+				this.#frameCounter++;
+				if (this.#frameCounter >= this.#analysisEveryFrames) {
+					this.#frameCounter = 0;
+					emit(this.#analyze());
+				}
+				const retained = this.#size - this.#hopSize;
+				if (retained)
+					this.#frame.copyWithin(0, this.#hopSize);
+				this.#frameLength = retained;
+			}
+		}
+	}
+
+	#analyze() {
+		const size = this.#size;
+		let mean = 0;
+		for (let i = 0; i < size; i++)
+			mean += this.#frame[i];
+		mean /= size;
+
+		// Place windowed samples in bit-reversed order for an in-place radix-2 FFT.
+		for (let i = 0; i < size; i++) {
+			const destination = this.#bitReverse[i];
+			this.#real[destination] = (this.#frame[i] - mean) * this.#window[i];
+			this.#imaginary[destination] = 0;
+		}
+
+		for (let span = 2; span <= size; span <<= 1) {
+			const half = span >> 1;
+			const twiddleStep = size / span;
+			for (let base = 0; base < size; base += span) {
+				for (let offset = 0; offset < half; offset++) {
+					const twiddle = offset * twiddleStep;
+					const odd = base + offset + half;
+					const even = base + offset;
+					const oddReal = (this.#cosine[twiddle] * this.#real[odd]) - (this.#sine[twiddle] * this.#imaginary[odd]);
+					const oddImaginary = (this.#cosine[twiddle] * this.#imaginary[odd]) + (this.#sine[twiddle] * this.#real[odd]);
+					const evenReal = this.#real[even];
+					const evenImaginary = this.#imaginary[even];
+					this.#real[even] = evenReal + oddReal;
+					this.#imaginary[even] = evenImaginary + oddImaginary;
+					this.#real[odd] = evenReal - oddReal;
+					this.#imaginary[odd] = evenImaginary - oddImaginary;
+				}
+			}
+		}
+
+		let peakBin = 1;
+		let peakPower = 0;
+		for (let bin = 1; bin < (size >> 1); bin++) {
+			const power = (this.#real[bin] * this.#real[bin]) + (this.#imaginary[bin] * this.#imaginary[bin]);
+			if (power > peakPower) {
+				peakPower = power;
+				peakBin = bin;
+			}
+		}
+
+		const levels = this.#levels;
+		const range = this.#maxDecibels - this.#minDecibels;
+		const history = this.#smoothing;
+		for (let band = 0; band < this.#bandCount; band++) {
+			const start = this.#bandStart[band];
+			const end = this.#bandEnd[band];
+			let power = 0;
+			for (let bin = start; bin < end; bin++)
+				power += (this.#real[bin] * this.#real[bin]) + (this.#imaginary[bin] * this.#imaginary[bin]);
+			const magnitude = (2 * Math.sqrt(power / (end - start))) / this.#windowSum;
+			let decibels = 20 * Math.log(magnitude + 1e-12) * LOG10;
+			decibels = (history * this.#smoothed[band]) + ((1 - history) * decibels);
+			this.#smoothed[band] = decibels;
+			let level = Math.round(255 * (decibels - this.#minDecibels) / range);
+			if (level < 0)
+				level = 0;
+			else if (level > 255)
+				level = 255;
+			levels[band] = level;
+		}
+
+		const peakMagnitude = (2 * Math.sqrt(peakPower)) / this.#windowSum;
+		const spectrum = this.#spectrum;
+		spectrum.peakFrequency = Math.round((peakBin * this.#sampleRate) / size);
+		spectrum.peakDecibels = 20 * Math.log(peakMagnitude + 1e-12) * LOG10;
+		return spectrum;
+	}
+}

--- a/spectrum-analyzer/main.js
+++ b/spectrum-analyzer/main.js
@@ -1,0 +1,59 @@
+import {} from "piu/MC";
+import runtimeConfig from "mc/config";
+import Timer from "timer";
+import AudioSampleStream from "audio-stream";
+import ToneSampleStream from "tone-stream";
+import SpectrumWorkerStream from "spectrum-worker-stream";
+import SpectrumPort from "spectrum-port";
+import config from "config";
+
+const MainApplication = Application.template(() => ({
+	skin: new Skin({ fill: "#071019" }),
+	contents: [
+		SpectrumPort(config),
+	],
+}));
+
+export default function () {
+	const application = new MainApplication({}, {
+		commandListLength: 4096,
+		displayListLength: 4096,
+		touchCount: 0,
+	});
+	const spectrumPort = application.first;
+
+	try {
+		const syntheticAudio = (runtimeConfig.syntheticAudio === true) || (runtimeConfig.syntheticAudio === "true");
+		const audio = syntheticAudio
+			? new ToneSampleStream({ sampleRate: config.sampleRate, frequency: 1000, chunkSize: config.inputChunkSize })
+			: new AudioSampleStream({ sampleRate: config.sampleRate });
+		spectrumPort.delegate("onSourceChanged", syntheticAudio ? "1 kHz TEST TONE" : "LISTENING");
+		trace(`spectrum source: ${syntheticAudio ? "1 kHz test tone" : "audio input"}\n`);
+		let firstSpectrum = true;
+		let latestSpectrum;
+		Timer.repeat(() => {
+			if (!latestSpectrum)
+				return;
+			spectrumPort.delegate("onSpectrum", latestSpectrum);
+			latestSpectrum = undefined;
+		}, Math.round(1000 / config.displayFPS));
+		const analyzer = new SpectrumWorkerStream({
+			onSpectrum(spectrum) {
+				if (firstSpectrum) {
+					trace(`first spectrum: ${spectrum.peakFrequency} Hz, ${Math.round(spectrum.peakDecibels)} dBFS\n`);
+					firstSpectrum = false;
+				}
+				latestSpectrum = spectrum;
+			},
+		});
+
+		audio.pipeTo(analyzer).catch(error => {
+			trace(`spectrum stream failed: ${error}\n`);
+			spectrumPort.delegate("onStreamError", error);
+		});
+	}
+	catch (error) {
+		trace(`audio input failed: ${error}\n`);
+		spectrumPort.delegate("onStreamError", error);
+	}
+}

--- a/spectrum-analyzer/manifest.json
+++ b/spectrum-analyzer/manifest.json
@@ -1,0 +1,40 @@
+{
+	"include": [
+		"$(MODDABLE)/examples/manifest_base.json",
+		"$(MODDABLE)/examples/manifest_piu.json",
+		"$(MODDABLE)/modules/base/worker/manifest.json",
+		"$(MODDABLE)/modules/io/manifest.json",
+		"$(MODDABLE)/modules/io/audioin/manifest.json",
+		"$(MODDABLE)/modules/web/streams/all/manifest.json"
+	],
+	"creation": {
+		"stack": 2048
+	},
+	"config": {
+		"startupSound": false
+	},
+	"defines": {
+		"audioIn": {
+			"sampleRate": 22050,
+			"numChannels": 1,
+			"bitsPerSample": 16
+		}
+	},
+	"modules": {
+		"*": [
+			"./main",
+			"./audio-stream",
+			"./tone-stream",
+			"./fft-spectrum",
+			"./spectrum-worker",
+			"./spectrum-worker-stream",
+			"./spectrum-port",
+			"./config"
+		]
+	},
+	"resources": {
+		"*-mask": [
+			"$(MODDABLE)/examples/assets/fonts/OpenSans-Regular-16"
+		]
+	}
+}

--- a/spectrum-analyzer/spectrum-port.js
+++ b/spectrum-analyzer/spectrum-port.js
@@ -1,0 +1,172 @@
+import {} from "piu/MC";
+
+const BACKGROUND = "#071019";
+const PANEL = "#0b1823";
+const GRID = "#203341";
+const AXIS = "#607786";
+const TEXT = "#d9f3ff";
+const DIM_TEXT = "#8ba5b4";
+const LOW = "#23d5ab";
+const MID = "#29b6f6";
+const HIGH = "#ffb547";
+const CLIP = "#ff5d73";
+const PEAK = "#e9fbff";
+
+const LeftStyle = new Style({ font: "16px Open Sans", horizontal: "left", vertical: "middle" });
+const CenterStyle = new Style({ font: "16px Open Sans", horizontal: "center", vertical: "middle" });
+const RightStyle = new Style({ font: "16px Open Sans", horizontal: "right", vertical: "middle" });
+
+function shortFrequency(frequency) {
+	if (frequency >= 1000) {
+		const tenths = Math.round(frequency / 100);
+		return `${Math.floor(tenths / 10)}.${tenths % 10}k`;
+	}
+	return `${frequency}`;
+}
+
+const SpectrumPort = Port.template(config => ({
+	left: 0, right: 0, top: 0, bottom: 0,
+	Behavior: class extends Behavior {
+		onCreate(port) {
+			this.config = config;
+			this.levels = new Uint8Array(config.bandCount);
+			this.peaks = new Uint8Array(config.bandCount);
+			this.peakFrequency = 0;
+			this.peakDecibels = config.minDecibels;
+			this.status = "LISTENING";
+			this.layoutWidth = 0;
+			this.layoutHeight = 0;
+		}
+
+		updateLayout(port) {
+			const width = port.width;
+			const height = port.height;
+			this.layoutWidth = width;
+			this.layoutHeight = height;
+			this.compact = height < 180;
+			this.headerHeight = this.compact ? 20 : 28;
+			this.footerHeight = this.compact ? 15 : 21;
+			this.plotLeft = width < 240 ? 22 : 34;
+			this.plotRight = 5;
+			this.plotTop = this.headerHeight;
+			this.plotBottom = height - this.footerHeight;
+			this.plotWidth = width - this.plotLeft - this.plotRight;
+			this.plotHeight = this.plotBottom - this.plotTop;
+			this.dataTop = this.plotTop + (this.compact ? 15 : 18);
+			this.dataHeight = this.plotBottom - this.dataTop;
+		}
+
+		onDisplaying(port) {
+			this.updateLayout(port);
+		}
+
+		onSpectrum(port, spectrum) {
+			this.levels = spectrum.levels;
+			this.peakFrequency = spectrum.peakFrequency;
+			this.peakDecibels = spectrum.peakDecibels;
+			for (let i = 0; i < this.peaks.length; i++) {
+				if (spectrum.levels[i] >= this.peaks[i])
+					this.peaks[i] = spectrum.levels[i];
+				else
+					this.peaks[i] = Math.max(0, this.peaks[i] - 5);
+			}
+			if (this.plotWidth)
+				port.invalidate(this.plotLeft, this.plotTop, this.plotWidth, this.plotHeight);
+			else
+				port.invalidate();
+		}
+
+		onSourceChanged(port, status) {
+			this.status = status;
+			port.invalidate();
+		}
+
+		onStreamError(port, error) {
+			this.status = `AUDIO ERROR: ${error}`;
+			port.invalidate();
+		}
+
+		drawPlot(port) {
+			const left = this.plotLeft;
+			const plotTop = this.plotTop;
+			const plotBottom = this.plotBottom;
+			const plotWidth = this.plotWidth;
+			const plotHeight = this.plotHeight;
+			const dataTop = this.dataTop;
+			const dataHeight = this.dataHeight;
+
+			port.fillColor(PANEL, left, plotTop, plotWidth, plotHeight);
+
+			for (let line = 0; line <= 4; line++) {
+				const y = dataTop + Math.round((line * dataHeight) / 4);
+				port.fillColor(GRID, left, y, plotWidth, 1);
+			}
+
+			const count = this.levels.length;
+			for (let i = 0; i < count; i++) {
+				const x0 = left + Math.floor((i * plotWidth) / count);
+				const x1 = left + Math.floor(((i + 1) * plotWidth) / count);
+				const barWidth = Math.max(1, x1 - x0 - 1);
+				const level = this.levels[i];
+				const barHeight = Math.round((level * dataHeight) / 255);
+				let color = LOW;
+				if (level > 218)
+					color = CLIP;
+				else if (level > 172)
+					color = HIGH;
+				else if (level > 100)
+					color = MID;
+				port.fillColor(color, x0, plotBottom - barHeight, barWidth, barHeight);
+
+				const peakY = plotBottom - Math.round((this.peaks[i] * dataHeight) / 255);
+				port.fillColor(PEAK, x0, peakY, barWidth, 1);
+			}
+
+			if (this.peakFrequency && (this.peakDecibels > this.config.minDecibels + 5)) {
+				const peak = `${shortFrequency(this.peakFrequency)}Hz  ${Math.round(this.peakDecibels)}dB`;
+				port.drawString(peak, RightStyle, TEXT, left, plotTop, plotWidth - 4, dataTop - plotTop);
+			}
+		}
+
+		drawChrome(port) {
+			const width = port.width;
+			const left = this.plotLeft;
+			const plotBottom = this.plotBottom;
+			const plotWidth = this.plotWidth;
+			const dataTop = this.dataTop;
+			const dataHeight = this.dataHeight;
+
+			port.drawString("SPECTRUM", LeftStyle, TEXT, 5, 0, width >> 1, this.headerHeight);
+			port.drawString(this.status, RightStyle, DIM_TEXT, width >> 1, 0, (width >> 1) - 5, this.headerHeight);
+
+			if (!this.compact) {
+				for (let line = 0; line <= 4; line++) {
+					const y = dataTop + Math.round((line * dataHeight) / 4);
+					port.drawString(`${-20 * line}`, RightStyle, AXIS, 0, y - 8, left - 4, 16);
+				}
+				port.drawString(`${this.config.minFrequency}`, LeftStyle, DIM_TEXT, left, plotBottom, 40, this.footerHeight);
+				const ratio = (Math.log(1000 / this.config.minFrequency) / Math.log((this.config.sampleRate / 2) / this.config.minFrequency));
+				const kiloX = left + Math.round(ratio * plotWidth) - 20;
+				port.drawString("1k", CenterStyle, DIM_TEXT, kiloX, plotBottom, 40, this.footerHeight);
+				port.drawString(`${Math.round(this.config.sampleRate / 2000)}k Hz`, RightStyle, DIM_TEXT, width - 55, plotBottom, 50, this.footerHeight);
+			}
+		}
+
+		onDraw(port, x, y, width, height) {
+			if ((this.layoutWidth !== port.width) || (this.layoutHeight !== port.height))
+				this.updateLayout(port);
+			const plotOnly = (x >= this.plotLeft) && (y >= this.plotTop)
+				&& ((x + width) <= (this.plotLeft + this.plotWidth))
+				&& ((y + height) <= (this.plotTop + this.plotHeight));
+			if (plotOnly) {
+				this.drawPlot(port);
+				return;
+			}
+			port.fillColor(BACKGROUND, 0, 0, port.width, port.height);
+			this.drawPlot(port);
+			this.drawChrome(port);
+		}
+	},
+}));
+
+export default SpectrumPort;

--- a/spectrum-analyzer/spectrum-worker-stream.js
+++ b/spectrum-analyzer/spectrum-worker-stream.js
@@ -1,0 +1,74 @@
+import Worker from "worker";
+import { WritableStream } from "web/streams";
+
+/* A one-in-flight WritableStream that applies real backpressure to AudioIn. */
+export default class SpectrumWorkerStream extends WritableStream {
+	constructor(options) {
+		let resolveWrite;
+		let rejectWrite;
+		const worker = new Worker("spectrum-worker", {
+			static: 48 * 1024,
+			chunk: {
+				initial: 20 * 1024,
+				incremental: 4 * 1024,
+			},
+			heap: {
+				initial: 1024,
+				incremental: 256,
+			},
+			stack: 256,
+			nativeStack: 8 * 1024,
+			priority: 1,
+		});
+
+		worker.onmessage = message => {
+			const resolve = resolveWrite;
+			const reject = rejectWrite;
+			resolveWrite = undefined;
+			rejectWrite = undefined;
+			if (message?.error) {
+				reject?.(new Error(message.error));
+				worker.terminate();
+				return;
+			}
+			try {
+				if (message !== 0)
+					options.onSpectrum(message);
+				resolve?.();
+			}
+			catch (error) {
+				reject?.(error);
+				worker.terminate();
+			}
+		};
+
+		super({
+			write(samples) {
+				return new Promise((resolve, reject) => {
+					resolveWrite = resolve;
+					rejectWrite = reject;
+					try {
+						worker.postMessage(samples);
+					}
+					catch (error) {
+						resolveWrite = undefined;
+						rejectWrite = undefined;
+						reject(error);
+					}
+				});
+			},
+			close() {
+				worker.terminate();
+			},
+			abort(reason) {
+				rejectWrite?.(reason);
+				resolveWrite = undefined;
+				rejectWrite = undefined;
+				worker.terminate();
+			},
+		}, {
+			highWaterMark: 1,
+			size() { return 1; },
+		});
+	}
+}

--- a/spectrum-analyzer/spectrum-worker.js
+++ b/spectrum-analyzer/spectrum-worker.js
@@ -1,0 +1,16 @@
+import FFTSpectrum from "fft-spectrum";
+import config from "config";
+
+const analyzer = new FFTSpectrum(config);
+
+self.onmessage = function(samples) {
+	try {
+		let spectrum;
+		analyzer.push(samples, result => spectrum = result);
+		// Every input receives an acknowledgement. Zero means no FFT was due.
+		self.postMessage(spectrum ?? 0);
+	}
+	catch (error) {
+		self.postMessage({ error: String(error) });
+	}
+};

--- a/spectrum-analyzer/tone-stream.js
+++ b/spectrum-analyzer/tone-stream.js
@@ -1,0 +1,49 @@
+import Timer from "timer";
+import { ReadableStream } from "web/streams";
+
+/* Deterministic input for simulator and automated pipeline verification. */
+export default class ToneSampleStream extends ReadableStream {
+	constructor(options) {
+		let timer;
+		let phase = 0;
+		const tableSize = 1024;
+		const phaseStep = (tableSize * options.frequency) / options.sampleRate;
+		const waveTable = new Int16Array(tableSize);
+		for (let i = 0; i < tableSize; i++)
+			waveTable[i] = Math.round(16384 * Math.sin((2 * Math.PI * i) / tableSize));
+		const samplePool = [
+			new Int16Array(options.chunkSize),
+			new Int16Array(options.chunkSize),
+			new Int16Array(options.chunkSize),
+		];
+		let poolIndex = 0;
+		const interval = Math.max(1, Math.round((1000 * options.chunkSize) / options.sampleRate));
+
+		super({
+			start(controller) {
+				timer = Timer.repeat(() => {
+					if (controller.desiredSize <= 0)
+						return;
+					const samples = samplePool[poolIndex];
+					poolIndex = (poolIndex + 1) % samplePool.length;
+					for (let i = 0; i < samples.length; i++) {
+						samples[i] = waveTable[phase | 0];
+						phase += phaseStep;
+						if (phase >= tableSize)
+							phase -= tableSize;
+					}
+					controller.enqueue(samples);
+				}, interval);
+			},
+			cancel() {
+				if (timer !== undefined) {
+					Timer.clear(timer);
+					timer = undefined;
+				}
+			},
+		}, {
+			highWaterMark: 2,
+			size() { return 1; },
+		});
+	}
+}


### PR DESCRIPTION
## What changed

- Add a `spectrum-analyzer` example using `AudioIn`, Web Streams, a Moddable Worker, and a single Piu `Port`.
- Add a deterministic 1 kHz synthetic input for LIN simulator verification.
- Document LIN debug/release commands, M5Stack Core2 usage, and debugger-related performance notes.
- Add the example to the repository README.

## Why

This provides a responsive real-time spectrum analyzer example for Moddable SDK 9.0.0. FFT work runs outside the Piu VM, drawing is capped and partially invalidated, and stream backpressure prevents latency from accumulating.

## Impact

Users can run the complete audio-to-FFT-to-display pipeline in the LIN simulator without a microphone, then build the same example for an AudioIn-capable embedded target.

## Validation

- `mcconfig -dn -m -t build -p lin -o <temp> syntheticAudio=true`
- FFT check with a 1 kHz / -6 dBFS synthetic signal: 1034 Hz, -6.87 dBFS
- `mcconfig -dn -m -t build -p esp32/m5stack_core2 -o <temp>`